### PR TITLE
Fix problems with link in tutorial

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -34,7 +34,7 @@ We will leave it to the reader to mentally convert `docker-compose` to `docker c
 3. Deploy Concourse using Docker Compose:
 
     ```plain
-    wget https://raw.githubusercontent.com/starkandwayne/concourse-tutorial/master/docker-compose.yml
+    wget https://raw.githubusercontent.com/Qarik-Group/concourse-tutorial/master/docker-compose.yml
     docker-compose up -d
     ```
     The following are common issues found when working with the tutorial 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -57,7 +57,7 @@ markdown_extensions:
       permalink: true
 
 repo_name: "help fix the tutorials"
-repo_url: "https://github.com/starkandwayne/concourse-tutorial"
+repo_url: "https://github.com/Qarik-Group/concourse-tutorial"
 edit_uri: edit/master/docs/
 extra_css: [print.css, stylesheets/extra.css]
 extra:


### PR DESCRIPTION
Change link of the tutorial for download docker-compose manifest for deploy concurse in docker locally.